### PR TITLE
Fixed test script and class to properly run inference on an image

### DIFF
--- a/test.py
+++ b/test.py
@@ -100,7 +100,8 @@ class LSD(object):
 
         img = cv2.imread(path_to_image)
         img = cv2.resize(img, (self.img_size, self.img_size))
-        img = torch.from_numpy(img[:, :, ::-1]).float().permute(2, 0, 1).unsqueeze(0)
+        img_reverse = img[..., [2, 1, 0]]
+        img = torch.from_numpy(img_reverse).float().permute(2, 0, 1).unsqueeze(0)
 
         if self.is_cuda:
             img = img.cuda()
@@ -114,13 +115,13 @@ class LSD(object):
         adj_mtx = adj_mtx_pred.cpu().numpy()
 
         img_with_junc = draw_jucntions(img, junctions_pred)
-        img_with_junc = img_with_junc[0].numpy()[:, ::-1, :, :]
+        img_with_junc = img_with_junc[0].numpy()[None]
+        img_with_junc = img_with_junc[:, ::-1, :, :]
         lines_pred, score_pred = graph2line(junctions_pred, adj_mtx)
         vis_line_pred = draw_lines(img_with_junc, lines_pred, score_pred)[0]
+        vis_line_pred = vis_line_pred.permute(1, 2, 0).numpy()
 
         cv2.imshow("result", vis_line_pred)
-
-        return self
 
 
 if __name__ == "__main__":

--- a/test.sh
+++ b/test.sh
@@ -2,7 +2,7 @@ python test.py \
 --exp-name line_weighted_wo_focal_junc --backbone resnet50 \
 --backbone-kwargs '{"encoder_weights": "ckpt/backbone/encoder_epoch_20.pth", "decoder_weights": "ckpt/backbone/decoder_epoch_20.pth"}' \
 --dim-embedding 256 --junction-pooling-threshold 0.2 \
---junc-pooling-size 64 --attention-sigma 1.5 --block-inference-size 128 \
---junc-sigma 3 --gpus 0, --resume-epoch latest \
+--junc-pooling-size 64 --block-inference-size 128 \
+--gpus 0, --resume-epoch latest \
 --vis-junc-th 0.25 --vis-line-th 0.25 \
     - test $1


### PR DESCRIPTION
These changes fix some errors that don't allow inference on a test image to run.  These include:

(1) `test.sh`: Removing some input parameters that the test class in `test.py` don't consume.  Not removing these generates errors.

(2) `test.py`:
- Removed `return self` so that displaying how to invoke the test class are suppressed in the `test` method.
- Mishandling between the conversion from NumPy arrays to Torch tensors and vice-versa have now been corrected referencing PyTorch v0.4.1.  One particular example is the creation of the `img_reverse` variable in this pull request where reversing the channels with a list in reverse order is required.  Not doing this generates an error where negative indices are not supported if using the original version of `test.py`.
- Improper swapping and permuting of channels in certain areas of the script are now corrected.